### PR TITLE
Char Length in Config

### DIFF
--- a/config/multiple-tokens-auth.php
+++ b/config/multiple-tokens-auth.php
@@ -15,6 +15,11 @@ return [
          * Value is in days.
         */
         'extend_life_at' => 10,
+
+        /*
+         * Amount of characters for tokens.
+        */
+        'char_length' => 80,
     ],
 
     /**

--- a/database/migrations/2019_12_29_134146_create_api_tokens_table.php
+++ b/database/migrations/2019_12_29_134146_create_api_tokens_table.php
@@ -15,7 +15,7 @@ class CreateApiTokensTable extends Migration
     {
         Schema::create(config('multiple-tokens-auth.table'), function (Blueprint $table) {
             $table->unsignedBigInteger('user_id')->index();
-            $table->string('token', 80)->unique();
+            $table->string('token', config('multiple-tokens-auth.token.char_length'))->unique();
             $table->dateTime('expired_at');
         });
     }

--- a/src/Traits/HasApiTokens.php
+++ b/src/Traits/HasApiTokens.php
@@ -19,7 +19,7 @@ trait HasApiTokens
         $hashedToken = null;
 
         while (! $unique) {
-            $token = Str::random(80);
+            $token = Str::random(config('multiple-tokens-auth.token.char_length'));
             $hashedToken = $useHash
                 ? hash('sha256', $token)
                 : $token;


### PR DESCRIPTION
Some application might chose to have a different `api_token` length than the standard 80. It also used to be 60 in previous Laravel versions and there is no reason it _has_ to be `80` afaik. To this way, it's at least configurable. I would need this features for a project and could use this package.