### PR TITLE
Fix token case-insensitive migration

### DIFF
--- a/database/migrations/2019_12_29_134146_create_api_tokens_table.php
+++ b/database/migrations/2019_12_29_134146_create_api_tokens_table.php
@@ -15,7 +15,7 @@ class CreateApiTokensTable extends Migration
     {
         Schema::create(config('multiple-tokens-auth.table'), function (Blueprint $table) {
             $table->unsignedBigInteger('user_id')->index();
-            $table->string('token', config('multiple-tokens-auth.token.char_length'))->unique();
+            $table->string('token', config('multiple-tokens-auth.token.char_length'))->collation('utf8mb4_bin')->unique();
             $table->dateTime('expired_at');
         });
     }


### PR DESCRIPTION
The default collation most DBs uses are likely to be case-insensitive. This means that it reduces the unique values tokens can be. Changing only the token field allows other fields to be anything else.